### PR TITLE
PERI Email names this variable TEMPLATING_SERVICE_URL, changing for consistency

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -5,8 +5,8 @@ const BASE_URL = "https://peri-templating-now.platforme.com/";
 export class API extends BaseAPI {
     constructor(kwargs = {}) {
         super(kwargs);
-        this.baseUrl = conf("PERI_TEMPLATING_BASE_URL", BASE_URL);
-        this.token = conf("PERI_TEMPLATING_TOKEN", null);
+        this.baseUrl = conf("TEMPLATING_SERVICE_URL", BASE_URL);
+        this.token = conf("TEMPLATING_SERVICE_TOKEN", null);
         this.baseUrl = kwargs.baseUrl === undefined ? this.baseUrl : kwargs.baseUrl;
         this.token = kwargs.token === undefined ? this.token : kwargs.token;
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | None |
| Dependencies | None |
| Decisions | `PERI Email` uses this same variable but calls it `TEMPLATING_SERVICE_URL`.  To be consistent, since it is the same variable, I renamed `PERI_TEMPLATING_BASE_URL` to `TEMPLATING_SERVICE_URL` and the token variable accordingly.  |
